### PR TITLE
Add a style prop to text

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -31,12 +31,17 @@ function Test() {
 
 render(
   <Chunk id="root">
-    <Text color="green" endl>
-      Hello world!
-      <Text color="blue" endl>
-        Hello world!
+    <Text style={{ color: 'yellow', fontWeight: 'bold' }} endl>
+      Some yellow and bold text {'\n'}
+      <Text
+        style={{ backgroundColor: 'rgb(230, 37, 101)', fontWeight: 'normal' }}
+        endl
+      >
+        Text with hot pink background
       </Text>
-      <Text endl>Hello world!</Text>
+      <Text style={{ textDecoration: 'underline' }} endl>
+        Yellow, bold and underlined text
+      </Text>
     </Text>
     <Text>{'\n'}</Text>
     <Counter />

--- a/example/index.js
+++ b/example/index.js
@@ -33,6 +33,10 @@ render(
   <Chunk id="root">
     <Text color="green" endl>
       Hello world!
+      <Text color="blue" endl>
+        Hello world!
+      </Text>
+      <Text endl>Hello world!</Text>
     </Text>
     <Text>{'\n'}</Text>
     <Counter />

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -4,43 +4,124 @@ import React, { Children } from 'react';
 import chalk from 'chalk';
 import { Chunk, Endl } from './';
 
+type Style = {|
+  color?: string,
+  backgroundColor?: string,
+  fontWeight?: 'bold' | 'normal',
+  fontStyle?: 'italic' | 'normal',
+  textDecoration?: 'underline' | 'line-through' | 'normal',
+  textTransform?: 'none' | 'capitalize' | 'uppercase' | 'lowercase',
+  visibility?: 'visible' | 'hidden',
+|};
+
 type Props = {
-  children: any,
-  color?: string | [number, number, number],
+  style?: Style,
   endl?: boolean,
+  children: any,
 };
 
-export default function Text(props: Props) {
-  const { children, color, endl } = props;
+function capitalize(text: string) {
+  return text
+    .split(' ')
+    .map(t => t.charAt(0).toUpperCase() + t.slice(1))
+    .join(' ');
+}
 
-  function colorize(text) {
-    if (color && Array.isArray(color)) {
-      return chalk.rgb(...color)(text);
-    } else if (color && /#/.test(color)) {
-      return chalk.hex(color)(text);
-    } else if (color) {
-      return chalk.keyword(color)(text);
-    }
-    return text;
+function stylize(style: Style, text: string) {
+  /* eslint-disable no-param-reassign */
+
+  let color = style.color;
+  let inverse = false;
+
+  if (style.backgroundColor) {
+    color = style.backgroundColor;
+    inverse = true;
   }
+
+  let enhancer = chalk.reset;
+
+  if (color) {
+    if (color.startsWith('#')) {
+      enhancer = enhancer.hex(color);
+    } else if (color.startsWith('rgb')) {
+      const rgb = color
+        .replace(/[rgb()]/g, '')
+        .split(',')
+        .map(i => parseInt(i, 10));
+      enhancer = chalk.rgb(...rgb);
+    } else {
+      enhancer = chalk.keyword(color);
+    }
+  }
+
+  if (inverse) {
+    enhancer = enhancer.inverse;
+  }
+
+  if (style.fontWeight === 'bold') {
+    enhancer = enhancer.bold;
+  }
+
+  if (style.fontStyle === 'italic') {
+    enhancer = enhancer.italic;
+  }
+
+  if (style.textDecoration) {
+    // eslint-disable-next-line default-case
+    switch (style.textDecoration) {
+      case 'underline':
+        enhancer = enhancer.underline;
+        break;
+      case 'line-through':
+        enhancer = enhancer.strikethrough;
+        break;
+    }
+  }
+
+  if (style.visibility === 'hidden') {
+    enhancer = enhancer.hidden;
+  }
+
+  if (style.textTransform) {
+    // eslint-disable-next-line default-case
+    switch (style.textTransform) {
+      case 'uppercase':
+        text = text.toUpperCase();
+        break;
+      case 'lowercase':
+        text = text.toLowerCase();
+        break;
+      case 'capitalize':
+        text = capitalize(text);
+        break;
+    }
+  }
+
+  return enhancer(text);
+}
+
+export default function Text(props: Props) {
+  const { children, style, endl } = props;
 
   return (
     <Chunk>
-      {typeof color === 'undefined'
-        ? children
-        : Children.map(children, child => {
-            if (typeof child === 'string') {
-              return colorize(child);
+      {style
+        ? Children.map(children, child => {
+            if (typeof child === 'string' || typeof child === 'number') {
+              return stylize(style, String(child));
             }
 
-            if (typeof child.props.color === 'undefined') {
+            if (child && child.type === Text) {
               return React.cloneElement(child, {
-                color,
+                style: child.props.style
+                  ? { ...style, ...child.props.style }
+                  : style,
               });
             }
 
             return child;
-          })}
+          })
+        : children}
       {endl ? <Endl /> : null}
     </Chunk>
   );

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { Children } from 'react';
 import chalk from 'chalk';
 import { Chunk, Endl } from './';
 
@@ -13,7 +13,7 @@ type Props = {
 export default function Text(props: Props) {
   const { children, color, endl } = props;
 
-  function enhance(text) {
+  function colorize(text) {
     if (color && Array.isArray(color)) {
       return chalk.rgb(...color)(text);
     } else if (color && /#/.test(color)) {
@@ -26,7 +26,21 @@ export default function Text(props: Props) {
 
   return (
     <Chunk>
-      {enhance(children)}
+      {typeof color === 'undefined'
+        ? children
+        : Children.map(children, child => {
+            if (typeof child === 'string') {
+              return colorize(child);
+            }
+
+            if (typeof child.props.color === 'undefined') {
+              return React.cloneElement(child, {
+                color,
+              });
+            }
+
+            return child;
+          })}
       {endl ? <Endl /> : null}
     </Chunk>
   );


### PR DESCRIPTION
This adds a style prop similar to web as well as adds support for nested text children.

It supports a very simple set of styles based on what's provided by `chalk`, and the property and value names match their web counterpart. The styles cascade down to the nested text elements.

![image](https://user-images.githubusercontent.com/1174278/31589320-f66fc566-b1ff-11e7-98dc-4761c20ec5ef.png)
