### PR TITLE
Batch flushes in one event loop

### DIFF
--- a/src/nodes/ContainerNode.js
+++ b/src/nodes/ContainerNode.js
@@ -23,11 +23,18 @@ export default class ContainerNode {
     return `${this.output}\n`;
   }
 
+  _batch = null;
+
   flush() {
     this.output = '';
     this.children.forEach(child => child.render());
+    this._batch = this._batch || setTimeout(() => this.update(), 0);
+  }
+
+  update() {
     readline.cursorTo(this.stream, 0, 0);
     readline.clearScreenDown(this.stream);
     this.stream.write(this.getOutput());
+    this._batch = null;
   }
 }


### PR DESCRIPTION
Batching multiple flushes together reduces number of writes to screen by a huge amount. In the example app, the number of writes went down to 17 from 337 (20 times less), and also removed a visible flickering in VSCode terminal.

This means that if multiple updates happen in very quick succession, they'll be skipped, but that's fine, because they won't be visible anyway. Normally we'd use requestAnimationFrame for this purpose, but no requestAnimationFrame available in Node, also not sure if we are aiming for 60 FPS in terminal 😛